### PR TITLE
Resolves #65, added treat missing data support

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -75,6 +75,7 @@ usage: |-
         actions_enabled           = true
         insufficient_data_actions = []
         ok_actions                = []
+        treat_missing_data        = "ignore"
         dimensions = {
           instance_id = module.ec2.instance_id[0]
         }

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "default" {
   actions_enabled           = var.actions_enabled
   insufficient_data_actions = var.insufficient_data_actions
   ok_actions                = var.ok_actions
+  treat_missing_data        = var.treat_missing_data
   tags                      = module.labels.tags
 
   dimensions = var.dimensions
@@ -52,6 +53,7 @@ resource "aws_cloudwatch_metric_alarm" "expression" {
   actions_enabled           = var.actions_enabled
   insufficient_data_actions = var.insufficient_data_actions
   ok_actions                = var.ok_actions
+  treat_missing_data        = var.treat_missing_data
   tags                      = module.labels.tags
   dynamic "metric_query" {
     for_each = var.query_expressions
@@ -97,6 +99,7 @@ resource "aws_cloudwatch_metric_alarm" "anomaly" {
   actions_enabled           = var.actions_enabled
   insufficient_data_actions = var.insufficient_data_actions
   ok_actions                = var.ok_actions
+  treat_missing_data        = var.treat_missing_data
   tags                      = module.labels.tags
   dynamic "metric_query" {
     for_each = var.query_expressions

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,12 @@ variable "insufficient_data_actions" {
   description = "The list of actions to execute when this alarm transitions into an INSUFFICIENT_DATA state from any other state."
 }
 
+variable "treat_missing_data" {
+  type        = string
+  default     = "missing"
+  description = "Sets how an alarm is going to handle missing data points."
+}
+
 variable "ok_actions" {
   type        = list(any)
   default     = []


### PR DESCRIPTION
## what
- Added treat missing data support.

## why
- it's an input that controls how the missing data will be processed. If you use alarm actions, it can lead to a spam when notifying to an SNS topic if the data is missing due to the alarm state change, leading to an alarm noise. With this improvement, we can control how to treat that missing data (missing, ignore, breaching and notBreaching) and avoid unnecessary alarm noise.

## references
- Resolves #65 
