### PR TITLE
Added datapoints to alarm support

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -76,6 +76,7 @@ usage: |-
         insufficient_data_actions = []
         ok_actions                = []
         treat_missing_data        = "ignore"
+        datapoints_to_alarm       = 2
         dimensions = {
           instance_id = module.ec2.instance_id[0]
         }

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "default" {
   insufficient_data_actions = var.insufficient_data_actions
   ok_actions                = var.ok_actions
   treat_missing_data        = var.treat_missing_data
+  datapoints_to_alarm       = var.datapoints_to_alarm
   tags                      = module.labels.tags
 
   dimensions = var.dimensions
@@ -54,6 +55,7 @@ resource "aws_cloudwatch_metric_alarm" "expression" {
   insufficient_data_actions = var.insufficient_data_actions
   ok_actions                = var.ok_actions
   treat_missing_data        = var.treat_missing_data
+  datapoints_to_alarm       = var.datapoints_to_alarm
   tags                      = module.labels.tags
   dynamic "metric_query" {
     for_each = var.query_expressions
@@ -100,6 +102,7 @@ resource "aws_cloudwatch_metric_alarm" "anomaly" {
   insufficient_data_actions = var.insufficient_data_actions
   ok_actions                = var.ok_actions
   treat_missing_data        = var.treat_missing_data
+  datapoints_to_alarm       = var.datapoints_to_alarm
   tags                      = module.labels.tags
   dynamic "metric_query" {
     for_each = var.query_expressions

--- a/variables.tf
+++ b/variables.tf
@@ -133,6 +133,12 @@ variable "treat_missing_data" {
   description = "Sets how an alarm is going to handle missing data points."
 }
 
+variable "datapoints_to_alarm" {
+  type        = number
+  default     = 1
+  description = "Sets the number of datapoints that must be breaching to trigger the alarm."
+}
+
 variable "ok_actions" {
   type        = list(any)
   default     = []


### PR DESCRIPTION
## what
* Added datapoints to alarm support.

## why
* It is needed to control the number of datapoints to alarm. When using treat_missing_data parameter without datapoints_to_alarm, terraform plans to change this parameter to NULL.

## references
* closes #67 
