### PR TITLE
fix: alarm naming convention to use aws-labels

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ module "labels" {
 resource "aws_cloudwatch_metric_alarm" "default" {
   count = var.enabled == true && var.expression_enabled == false && var.threshold_metric_id == "" ? 1 : 0
 
-  alarm_name                = var.alarm_name
+  alarm_name                = module.labels.id
   alarm_description         = var.alarm_description
   comparison_operator       = var.comparison_operator
   evaluation_periods        = var.evaluation_periods


### PR DESCRIPTION
### Before
Earlier the CloudWatch Alarm was being created with name passed in `alarm_name` variable instead of `aws-labels` we are using.
```hcl
resource "aws_cloudwatch_metric_alarm" "..." {
  ...
  alarm_name                = var.alarm_name
  ...
}
```
### Now
Now the CloudWatch Alarm is getting created with namm according to the `name`, `environment` & `label_order` labels.
```hcl
resource "aws_cloudwatch_metric_alarm" "..." {
  ...
  alarm_name                = module.labels.id 
  ...
```
